### PR TITLE
ci: add Docker build and push to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,19 @@ jobs:
       run: |
         cd backend
         pytest tests
+        
+    - name: Build Docker Image
+      run: |
+        docker build -t ${{ secrets.DOCKER_USERNAME }}/job-management-backend:${{ github.sha }} ./backend
+
+    - name: Scan Docker Image
+      run: |
+        docker pull aquasec/trivy:latest
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/root/.cache/ aquasec/trivy:latest image ${{ secrets.DOCKER_USERNAME }}/job-management-backend:${{ github.sha }}
+
+    - name: Push Docker Image
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        docker push ${{ secrets.DOCKER_USERNAME }}/job-management-backend:${{ github.sha }}
+        docker logout


### PR DESCRIPTION
- Added step to build Docker image from backend directory.
- Push Docker image to Docker Hub with commit SHA as tag.
- Log in to Docker Hub using secrets.
- Conditional step execution only on push to main branch.