### PR TITLE
ci: fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "8000:80"
     environment:
-      SQLALCHEMY_DATABASE_URL: "mysql+pymysql://root:1234@mysql:3307/job_management"
+      DATABASE_URL: "mysql+pymysql://root:1234@mysql:3306/job_management"
     depends_on:
       - mysql
 


### PR DESCRIPTION
- Fix docker compose backend environment variable name from SQLALCHEMY_DATABASE_URL to DATABASE_URL.