### PR TITLE
feat($frontend): use isFirstLoad to prevent unnecessary API calls

### DIFF
--- a/frontend/src/hooks/JobView/useFetchJobs.js
+++ b/frontend/src/hooks/JobView/useFetchJobs.js
@@ -10,6 +10,7 @@ export const useFetchJobs = () => {
   const [jobs, setJobs] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [isFirstLoad, setIsFirstLoad] = useState(true)
 
   const fetchJobs = async () => {
     setLoading(true)
@@ -17,6 +18,7 @@ export const useFetchJobs = () => {
       const data = await fetchJobsAPI()
       setJobs(data)
       setError(null)
+      setIsFirstLoad(false) 
     } catch (error) {
       setError('Failed to fetch jobs')
       console.error('Error fetching jobs:', error)
@@ -26,8 +28,10 @@ export const useFetchJobs = () => {
   }
 
   useEffect(() => {
-    fetchJobs()
-  }, [])
+    if (isFirstLoad) {
+      fetchJobs()
+    }
+  }, [isFirstLoad])
 
   return { jobs, loading, error, fetchJobs }
 }

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -51,7 +51,6 @@ export const fetchJobById = async (id) => {
   }
 }
 
-// Similarly, update other functions to validate data format
 export const createJob = async (jobData) => {
   try {
     const response = await axios.post(`${BASE_URL}jobs`, jobData)


### PR DESCRIPTION
- Add isFirstLoad state to track initial data fetch.
- Prevent API calls on subsequent renders unless manually triggered.
- Update useFetchJobs hook to utilize isFirstLoad for optimized performance.