### PR TITLE
fix: resolve nginx 404 refresh issue and enhance Docker Compose build…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   mysql:
@@ -11,13 +11,15 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test:
+        ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p1234 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
 
   backend:
-    image: jack20499/job-management-backend
+    build:
+      context: ./backend
     ports:
       - "8000:80"
     environment:
@@ -27,7 +29,8 @@ services:
         condition: service_healthy
 
   frontend:
-    image: jack20499/job-management-frontend
+    build:
+      context: ./frontend
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,8 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
+RUN rm /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,19 +1,47 @@
-server {
-    listen 80;
-    server_name localhost;
+worker_processes  1;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
 
-    root /usr/share/nginx/html;
-    index index.html index.htm;
+events {
+    worker_connections  1024;
+}
 
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-    location /api/ {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html;
+            error_log /var/log/nginx/custom_error.log;
+        }
+
+
+        location /api/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
     }
 }


### PR DESCRIPTION
… process

- Fix nginx 404 refresh issue by adding custom configuration in Dockerfile:
  - COPY `nginx.conf` to `/etc/nginx/nginx.conf`.
  - Remove default configuration: RUN `rm /etc/nginx/conf.d/default.conf`.
- Add `nginx.conf` in frontend.
- Add build support for frontend and backend services in Docker Compose.